### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -141,7 +141,7 @@ class syntax_plugin_revisionsdue extends DokuWiki_Syntax_Plugin {
      * Handle the match
      */
  
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         $match_array = array();
         $match = substr($match,12,-2); //strip ~~REVISIONS: from start and ~~ from end
         // Wolfgang 2007-08-29 suggests commenting out the next line
@@ -156,7 +156,7 @@ class syntax_plugin_revisionsdue extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($format, &$renderer, $data) {
+    function render($format, Doku_Renderer $renderer, $data) {
         global $INFO, $conf;
 
         if($format == 'xhtml'){


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
